### PR TITLE
adding the /Patient route.

### DIFF
--- a/lib/hotaru_swarm_web/router.ex
+++ b/lib/hotaru_swarm_web/router.ex
@@ -24,6 +24,11 @@ defmodule HotaruSwarmWeb.Router do
     get "/$export", BulkJobController, :create
   end
 
+  scope "/fhir/Patient", HotaruSwarmWeb do
+    pipe_through :api
+    get "/$export", BulkJobController, :create
+  end
+
   scope "/bulk_jobs", HotaruSwarmWeb do
     pipe_through :api
     get "/:id", BulkJobController, :show


### PR DESCRIPTION
Based on the current specs, the /Patient endpoint is for exporting all patient-related resources and the root export is only for non-patient-related resources. 
This needs actual verification of what resource types are being requested under each path but until that becomes a thing this enables clients to fetch data from the /Patient endpoint. 